### PR TITLE
Add support for elasticsearch-php v6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
   - hhvm
 
 sudo: false

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "elasticsearch/elasticsearch": "^2.1|^5.0",
+        "elasticsearch/elasticsearch": "^2.1|^5.0|^6.0",
         "aws/aws-sdk-php": "^3.0"
     },
     "require-dev": {


### PR DESCRIPTION
Elasticsearch 6 still uses RingPHP, so no changes beyond expanding the version constraint in `composer.json` were required.

Resolves #8 