### PR TITLE
Fix for HEAD requests failing due to non-null message bodies

### DIFF
--- a/src/ElasticsearchPhpHandler.php
+++ b/src/ElasticsearchPhpHandler.php
@@ -82,11 +82,19 @@ class ElasticsearchPhpHandler
     private function createRingRequest(RequestInterface $request)
     {
         $uri = $request->getUri();
+        $body = (string) $request->getBody();
+
+        // RingPHP currently expects empty message bodies to be null:
+        // https://github.com/guzzle/RingPHP/blob/4c8fe4c48a0fb7cc5e41ef529e43fecd6da4d539/src/Client/CurlFactory.php#L202
+        if (empty($body)) {
+            $body = null;
+        }
+
         $ringRequest = [
             'http_method' => $request->getMethod(),
             'scheme' => $uri->getScheme(),
             'uri' => $uri->getPath(),
-            'body' => (string) $request->getBody(),
+            'body' => $body,
             'headers' => $request->getHeaders(),
         ];
         if ($uri->getQuery()) {

--- a/tests/ElasticsearchPhpHandlerTest.php
+++ b/tests/ElasticsearchPhpHandlerTest.php
@@ -61,6 +61,41 @@ class ElasticsearchPhpHandlerTest extends \PHPUnit_Framework_TestCase
         ]);
     }
 
+    public function testEmptyRequestBodiesShouldBeNull()
+    {
+        $toWrap = function (array $ringRequest) {
+            $this->assertNull($ringRequest['body']);
+
+            return $this->getGenericResponse();
+        };
+
+        $client = $this->getElasticsearchClient(
+            new ElasticsearchPhpHandler('us-west-2', null, $toWrap)
+        );
+
+        $client->indices()->exists(['index' => 'index']);
+    }
+
+    public function testNonEmptyRequestBodiesShouldNotBeNull()
+    {
+        $toWrap = function (array $ringRequest) {
+            $this->assertNotNull($ringRequest['body']);
+
+            return $this->getGenericResponse();
+        };
+
+        $client = $this->getElasticsearchClient(
+            new ElasticsearchPhpHandler('us-west-2', null, $toWrap)
+        );
+
+        $client->search([
+            'index' => 'index',
+            'body' => [
+                'query' => [ 'match_all' => (object)[] ],
+            ],
+        ]);
+    }
+
     private function getElasticsearchClient(ElasticsearchPhpHandler $handler)
     {
         $builder = ClientBuilder::create()


### PR DESCRIPTION
Performing an `indices()->exists()` call on an AWS Elasticsearch instance kept throwing a _'No alive nodes found in your cluster'_ exception.

Long story short: RingPHP sets the [`CURLOPT_NOBODY`](https://curl.haxx.se/libcurl/c/CURLOPT_NOBODY.html) option when the request method is set to [HEAD](https://github.com/guzzle/RingPHP/blob/4c8fe4c48a0fb7cc5e41ef529e43fecd6da4d539/src/Client/CurlFactory.php#L215). But only [if the body is null](https://github.com/guzzle/RingPHP/blob/4c8fe4c48a0fb7cc5e41ef529e43fecd6da4d539/src/Client/CurlFactory.php#L202). Due to the [cast](https://github.com/jeskew/amazon-es-php/blob/643eb1a17485c32d00a4029781296a662f84f719/src/ElasticsearchPhpHandler.php#L89) to `string` in `createRingRequest()`, the body was never null and the `CURLOPT_NOBODY` option never set. And so cURL timed out waiting for a response body that never came.

This PR fixes that 👍🏻