### PR TITLE
Update PHPUnit syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ vendor/
 composer.lock
 
 /phpunit.xml
+/.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
 language: php
 
 php:
-  - 5.5
   - 5.6
   - 7.0
   - 7.1
   - 7.2
-  - hhvm
+  - 7.3
 
 sudo: false
 
@@ -16,10 +15,12 @@ env:
 
 matrix:
   allow_failures:
-    - php: hhvm
+    - php: 7.3
+      env: COMPOSER_OPTS="--prefer-lowest" # Elasticsearch-PHP 2.1 (a very old
+                                      # version) is not compatible with PHP 7.3
   fast_finish: true
 
 install:
-  - travis_retry composer update $COMPOSER_OPTS --no-interaction --prefer-source
+  - travis_retry composer update $COMPOSER_OPTS --no-interaction
 
 script: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,11 @@
         }
     ],
     "require": {
-        "elasticsearch/elasticsearch": "^2.1|^5.0|^6.0",
+        "elasticsearch/elasticsearch": "^2.1|^5.0|^6.0|^7.0",
         "aws/aws-sdk-php": "^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0|~5.0"
+        "phpunit/phpunit": "^4.8.35|^5.4.0|^6.0.0|^7.0.0|^8.0.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/ElasticsearchPhpHandler.php
+++ b/src/ElasticsearchPhpHandler.php
@@ -56,8 +56,10 @@ class ElasticsearchPhpHandler
 
         // Amazon ES listens on standard ports (443 for HTTPS, 80 for HTTP).
         // Consequently, the port should be stripped from the host header.
-        $ringPhpRequest['headers'][$hostKey][0]
-            = parse_url($ringPhpRequest['headers'][$hostKey][0])['host'];
+        $parsedUrl = parse_url($ringPhpRequest['headers'][$hostKey][0]);
+        if (isset($parsedUrl['host'])) {
+            $ringPhpRequest['headers'][$hostKey][0] = $parsedUrl['host'];
+        }
 
         // Create a PSR-7 URI from the array passed to the handler
         $uri = (new Uri($ringPhpRequest['uri']))

--- a/tests/ElasticsearchPhpHandlerTest.php
+++ b/tests/ElasticsearchPhpHandlerTest.php
@@ -5,8 +5,9 @@ use Aws\Credentials\CredentialProvider;
 use Aws\Credentials\Credentials;
 use Elasticsearch\ClientBuilder;
 use GuzzleHttp\Ring\Future\CompletedFutureArray;
+use PHPUnit\Framework\TestCase;
 
-class ElasticsearchPhpHandlerTest extends \PHPUnit_Framework_TestCase
+class ElasticsearchPhpHandlerTest extends TestCase
 {
     public function testSignsRequestsTheSdkDefaultCredentialProviderChain()
     {
@@ -18,7 +19,7 @@ class ElasticsearchPhpHandlerTest extends \PHPUnit_Framework_TestCase
                 "~^AWS4-HMAC-SHA256 Credential=$key/\\d{8}/us-west-2/es/aws4_request~",
                 $ringRequest['headers']['Authorization'][0]
             );
-            
+
             return $this->getGenericResponse();
         };
         putenv(CredentialProvider::ENV_KEY . "=$key");
@@ -26,14 +27,14 @@ class ElasticsearchPhpHandlerTest extends \PHPUnit_Framework_TestCase
         $client = $this->getElasticsearchClient(
             new ElasticsearchPhpHandler('us-west-2', null, $toWrap)
         );
-        
+
         $client->get([
             'index' => 'index',
             'type' => 'type',
             'id' => 'id',
         ]);
     }
-    
+
     public function testSignsWithProvidedCredentials()
     {
         $provider = CredentialProvider::fromCredentials(
@@ -43,7 +44,7 @@ class ElasticsearchPhpHandlerTest extends \PHPUnit_Framework_TestCase
             $this->assertArrayHasKey('X-Amz-Security-Token', $ringRequest['headers']);
             $this->assertSame('baz', $ringRequest['headers']['X-Amz-Security-Token'][0]);
             $this->assertRegExp(
-                '~^AWS4-HMAC-SHA256 Credential=foo/\d{8}/us-west-2/es/aws4_request~', 
+                '~^AWS4-HMAC-SHA256 Credential=foo/\d{8}/us-west-2/es/aws4_request~',
                 $ringRequest['headers']['Authorization'][0]
             );
 
@@ -53,7 +54,7 @@ class ElasticsearchPhpHandlerTest extends \PHPUnit_Framework_TestCase
         $client = $this->getElasticsearchClient(
             new ElasticsearchPhpHandler('us-west-2', $provider, $toWrap)
         );
-        
+
         $client->get([
             'index' => 'index',
             'type' => 'type',
@@ -107,7 +108,7 @@ class ElasticsearchPhpHandlerTest extends \PHPUnit_Framework_TestCase
 
         return $builder->build();
     }
-    
+
     private function getGenericResponse()
     {
         return new CompletedFutureArray([


### PR DESCRIPTION
Use namespaced import syntax to allow using a current version of PHPUnit. Also updates the Travis configuration to exclude PHP 5.5 and HHVM 