### PR TITLE
Change Elasticsearch-php into a suggested library together with Opensearch-php

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
+  - 8.1
 
 sudo: false
 
@@ -16,11 +17,13 @@ env:
 matrix:
   allow_failures:
     - php: 7.3
-      env: COMPOSER_OPTS="--prefer-lowest" # Elasticsearch-PHP 2.1 (a very old
-                                      # version) is not compatible with PHP 7.3
+      env: COMPOSER_OPTS="--prefer-lowest" # Elasticsearch-PHP 2.1 (a very old version) is not compatible with PHP 7.3
+    - php: 8.1
+      env: COMPOSER_OPTS="--prefer-lowest" # Elasticsearch-PHP 2.1 (a very old version) is not compatible with PHP 8.1
   fast_finish: true
 
 install:
   - travis_retry composer update $COMPOSER_OPTS --no-interaction
+  - travis_retry composer require elasticsearch/elasticsearch:">=2.1 <8.0" $COMPOSER_OPTS --no-interaction
 
 script: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "jsq/amazon-es-php",
     "description": "Support for using IAM authentication with the official Elasticsearch PHP client",
-    "keywords": ["elasticsearch", "aws", "search", "client", "iam"],
+    "keywords": ["elasticsearch", "opensearch", "aws", "search", "client", "iam"],
     "minimum-stability": "stable",
     "license": "Apache-2.0",
     "authors": [
@@ -11,11 +11,15 @@
         }
     ],
     "require": {
-        "elasticsearch/elasticsearch": "^2.1|^5.0|^6.0|^7.0",
-        "aws/aws-sdk-php": "^3.0"
+        "aws/aws-sdk-php": "^3.0",
+        "ezimuel/ringphp": "^1.1.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.35|^5.4.0|^6.0.0|^7.0.0|^8.0.0"
+    },
+    "suggest": {
+        "elasticsearch/elasticsearch": "Require `elasticsearch/elasticsearch` when using Elasticsearch on AWS",
+        "opensearch-project/opensearch-php": "Require `opensearch-project/opensearch-php` when using Opensearch on AWS"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,11 @@
         }
     ],
     "require": {
-        "aws/aws-sdk-php": "^3.0",
-        "ezimuel/ringphp": "^1.1.2"
+        "aws/aws-sdk-php": "^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8.35|^5.4.0|^6.0.0|^7.0.0|^8.0.0"
+        "phpunit/phpunit": "^4.8.35|^5.4.0|^6.0.0|^7.0.0|^8.0.0",
+        "ezimuel/ringphp": "^1.1.2"
     },
     "suggest": {
         "elasticsearch/elasticsearch": "Require `elasticsearch/elasticsearch` when using Elasticsearch on AWS",


### PR DESCRIPTION
This pull requests removes the requirement for the elasticsearch-php library and adds it as a suggested library, together with opensearch-php. 

This way we can use this package with either library without installing and requiring unused code. Related issue: https://github.com/jeskew/amazon-es-php/issues/25

This PR also adds a test case for PHP8.1 and throws an exception when Elasticsearch-PHP version 8 is used which is incompatible. The setHandler method is removed from the ClientBuilder.


## TODO
The documentation is not modified yet. I wanted to open this PR first to present this solution.
